### PR TITLE
Remove duplicate `:` character.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -422,7 +422,7 @@ class Server extends KarmaEventEmitter {
     })
 
     processWrapper.on('uncaughtException', (error) => {
-      this.log.error(`UncaughtException:: ${error.stack || error.message || String(error)}`)
+      this.log.error(`UncaughtException: ${error.stack || error.message || String(error)}`)
       reportError(error)
     })
   }


### PR DESCRIPTION
Nothing else to say.